### PR TITLE
Fix $RUBY_GEMS_ROOT in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM centos:7
 MAINTAINER ManageIQ https://github.com/ManageIQ/container-ruby
 
 ## For ruby
-ENV RUBY_GEMS_ROOT=/opt/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0 \
-    PATH=$PATH:/opt/rubies/ruby-2.3.1/bin \
+ENV RUBY_GEMS_ROOT=/usr/local/lib/ruby/gems/2.3.0 \
     LANG=en_US.UTF-8
 
 # Install repos


### PR DESCRIPTION
With the addition from ea8c9653 :

> Install ruby with --system

To the Dockerfile, this makes it so ruby is no longer installed into `/opt/rubies/ruby-2.3.1`, but instead `/usr/local/lib/ruby` (the behavior of `--system` in `ruby-install`).  This fix updates the `RUBY_GEMS_ROOT` ENV variable to reflect that properly.

This also means that `/usr/local/bin` already has the `ruby` binary installed, so modifying the `$PATH` is no longer necessary.

This was throwing me off quite significantly hen working with this container image.


Links
-----

* [ManageIQ/container-ruby#4](https://github.com/ManageIQ/container-ruby/pull/4)