### PR TITLE
Changes for adding ppc64le support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
     curl -sL https://copr.fedorainfracloud.org/coprs/manageiq/ManageIQ-Master/repo/epel-7/manageiq-ManageIQ-Master-epel-7.repo -o /etc/yum.repos.d/manageiq.repo
 
 # Install ruby-install and make
-RUN yum -y install --setopt=tsflags=nodocs ruby-install make
+RUN yum -y install --setopt=tsflags=nodocs bzip2 make wget
 
-RUN ruby-install --system ruby 2.5.7 -- --disable-install-doc --enable-shared && rm -rf /usr/local/src/* && yum clean all
+RUN wget -O ruby-install-0.7.0.tar.gz https://github.com/postmodern/ruby-install/archive/v0.7.0.tar.gz && \
+        tar -xzvf ruby-install-0.7.0.tar.gz && \
+        cd ruby-install-0.7.0/ && \
+        make install


### PR DESCRIPTION
To enable building of manageiq-pods and manageiq docker images on IBM Power (ppc64le) platform.